### PR TITLE
Disable Apache port 80

### DIFF
--- a/templates/ports.conf
+++ b/templates/ports.conf
@@ -1,0 +1,5 @@
+# File written by Juju: don't open default ports on SSL environments (see LP 1845665).
+<IfModule !ssl_module>
+    Listen 80
+</IfModule>
+


### PR DESCRIPTION
Currently, Apache ports.conf file is not being configured by the reactive charms. This patch is one part in a series of patches that changes the ports.conf default file with another one that does not open port 80 on SSL environments.

Closes-bug: #1845665