### PR TITLE
fix: actions need hooks/

### DIFF
--- a/actions/os_actions.py
+++ b/actions/os_actions.py
@@ -18,6 +18,9 @@ import sys
 
 # Load modules from $CHARM_DIR/lib
 sys.path.append('lib')
+# Some charms include extra functionality in the hooks/ directory
+# Load modules from $CHARM_DIR/hooks (eg hooks/relations)
+sys.path.append('hooks')
 
 from charms.layer import basic
 basic.bootstrap_charm_deps()


### PR DESCRIPTION
Some charm builds will put additional functionality into a subdirectory of hooks/ (eg designate-bind creates a hooks/relations directory.)

However, when running an action, those are run from "actions/pause" not as "hooks/config-changed". Which means that they cannot find the "relations" directory to import it.

We could:
a) symlink all the extra things from actions/* to point at hooks/*
b) include hooks as part of the import path
c) change so that all of those extra libraries are put into somewhere in 'lib' instead of somewhere in hooks/*.

This patch chooses (b).

This should fix:
https://bugs.launchpad.net/charm-designate-bind/+bug/2107591

once it is rebuilt with this version of layer openstack.